### PR TITLE
Fix model booting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-All notable changes to `default-model-sorting` will be documented in this file
+## 1.0.0 - 2020-07-01
 
-## 1.0.0 - 201X-XX-XX
+- Initial release
 
-- initial release
+## 1.0.1 - 2020-07-12
+
+- Update global scope name

--- a/src/Traits/DefaultOrderBy.php
+++ b/src/Traits/DefaultOrderBy.php
@@ -12,8 +12,10 @@ trait DefaultOrderBy
             return;
         }
 
-        $direction = isset(Self::$orderByColumnDirection)
-            ? Self::$orderByColumnDirection
+        $column = self::$orderByColumn;
+
+        $direction = isset(self::$orderByColumnDirection)
+            ? self::$orderByColumnDirection
             : config('default-model-sorting.order_by');
 
         static::addGlobalScope('default_order_by', function (Builder $builder) use ($column, $direction) {

--- a/src/Traits/DefaultOrderBy.php
+++ b/src/Traits/DefaultOrderBy.php
@@ -6,10 +6,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 trait DefaultOrderBy
 {
-    protected static function boot()
+    protected static function bootDefaultOrderBy()
     {
-        parent::boot();
-
         $column = Self::$orderByColumn;
 
         $direction = isset(Self::$orderByColumnDirection)

--- a/src/Traits/DefaultOrderBy.php
+++ b/src/Traits/DefaultOrderBy.php
@@ -8,7 +8,9 @@ trait DefaultOrderBy
 {
     protected static function bootDefaultOrderBy()
     {
-        $column = Self::$orderByColumn;
+        if (empty(self::$orderByColumn)) {
+            return;
+        }
 
         $direction = isset(Self::$orderByColumnDirection)
             ? Self::$orderByColumnDirection


### PR DESCRIPTION
Laravel looks for a method named `boot<TraitName>` so that traits can boot while still allowing the model itself to have a `boot()` method. [More info can be found here.](archybold.com/blog/post/booting-eloquent-model-traits)

This PR simply changes the `boot()` method name to `bootDefaultOrderBy()` so that it doesn't collide with existing model `boot()` methods. It also prevents an error when `$orderByColumn` isn't defined (it just returns, doing nothing)

I put the releases in the changelog too ;)

Thanks!